### PR TITLE
feat: add radixui utility classes for tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "^6.22.1",
-    "react-router-dom": "^6.22.1"
+    "react-router-dom": "^6.22.1",
+    "tailwindcss-radix": "^2.8.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.55",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: [
-  "./index.html",
-  "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {},
   },
-  plugins: [],
-}
-
+  plugins: [
+    import("tailwindcss-radix")({
+      variantPrefix: "data",
+    }),
+  ],
+};


### PR DESCRIPTION
RadixUI components have states that indicate things such as when an Accordion Item is open or not. These states are handled with custom parameters that cannot be targeted with Tailwind. Here's an example of how it works with regular CSS:
```jsx
const AccordionDemo = () => (
  <Accordion.Root>
    <Accordion.Item className="AccordionItem" value="item-1" />
    {/* … */}
  </Accordion.Root>
);
```
```css
.AccordionItem[data-state='open'] {
  border-bottom-width: 2px;
}
```

However, this can be fixed with a library. It is configured to have the "data" prefix so it will be more intuitive to style when following Radix's documentation:
```jsx
const AccordionDemo = () => (
  <Accordion.Root>
    <Accordion.Item className="data-state-open:border-b-2" value="item-1" />
    {/* … */}
  </Accordion.Root>
);
```