### PR TITLE
feat: add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:21-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 5173
+
+CMD npm run dev --host

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,10 @@ import { VitePWA } from "vite-plugin-pwa";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    host: true,
+    port: 5173,
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
Added a Dockerfile to allow running the app with Docker. The URL in the browser should stay the same.

Additionally, Vite requires hosting to be enabled in order to access the application from things like a web browser in the host machine. 

Closes #24 