### PR TITLE
Feature/24 Remove unnecessary environment variable for Docker

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -1,1 +1,0 @@
-VITE_BACKEND_URL = "http://backend:8000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,9 +39,6 @@ services:
     volumes:
       - ./musclemate-frontend/src/:/app/src
       - type: bind
-        source: ./musclemate-frontend/.env.docker
-        target: /app/.env
-      - type: bind
         source: ./musclemate-frontend/package.json
         target: /app/package.json
       - type: bind

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,13 +37,7 @@ services:
     links:
       - backend
     volumes:
-      - ./musclemate-frontend/src/:/app/src
-      - type: bind
-        source: ./musclemate-frontend/package.json
-        target: /app/package.json
-      - type: bind
-        source: ./musclemate-frontend/package-lock.json
-        target: /app/package-lock.json
+      - ./musclemate-frontend/:/app/
 
 volumes:
   postgres_data:


### PR DESCRIPTION
As it turns out, docker uses the exposed ports at localhost to fetch changes. Therefore, in order to fetch from the backend it's still localhost:8000, not docker compose's network IP.

Therefore, its custom .env has been removed.