### PR TITLE
feat: owner subscription plan type

### DIFF
--- a/src/utils/context/SubscriptionContext.jsx
+++ b/src/utils/context/SubscriptionContext.jsx
@@ -1,12 +1,22 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { createContext } from 'react'
+import { getFromApi } from '../functions/api';
+import AuthContext from './AuthContext';
+import Stripe from 'stripe';
 
+const STRIPE_SECRET_KEY = import.meta.env.VITE_STRIPE_SECRET_KEY
 const SubscriptionContext = createContext()
 
 export default SubscriptionContext;
 
 export function SubscriptionProvider( {children} ) {
 
+    const stripe = new Stripe(STRIPE_SECRET_KEY)
+
+    const {user} = useContext(AuthContext)
+
+    const [ownerSubscription, setOwnerSubscription] = useState(() =>
+    localStorage.getItem('ownerSubscription') ? JSON.parse(localStorage.getItem('ownerSubscription')) : [])
     const [gymnSubscription, setGymnSubscription] = useState(() =>
     localStorage.getItem('gymSubscription') ? JSON.parse(localStorage.getItem('gymSubscription')) : [])
 
@@ -14,11 +24,21 @@ export function SubscriptionProvider( {children} ) {
         localStorage.setItem('gymSubscription', JSON.stringify(gymnSubscription));
     }
 
+    const getOwnerSubscription = async () => {
+        if (user.rol === 'owner') {
+            const gyms = await getFromApi(`gyms/`)
+            const gyms_list = await gyms.json()
+            const gymSubscription = gyms_list.filter(gym => gym.subscription_plan !== 'free')
+            await setOwnerSubscription({
+                owner_plan: gymSubscription[0].subscription_plan})            
+        }
+        localStorage.setItem('ownerSubscription', JSON.stringify(ownerSubscription));
+    }
     
 
   
     return (
-    <SubscriptionContext.Provider value={{gymnSubscription, setGymnSubscription, saveGymnSubscription}} >
+    <SubscriptionContext.Provider value={{gymnSubscription, setGymnSubscription, saveGymnSubscription, getOwnerSubscription, ownerSubscription}} >
         {children}
     </SubscriptionContext.Provider>
   )

--- a/src/views/MainLayout/MainLayout.jsx
+++ b/src/views/MainLayout/MainLayout.jsx
@@ -7,8 +7,8 @@ import { SubscriptionProvider } from "../../utils/context/SubscriptionContext";
 
 const MainLayout = ({ children }) => {
   return (
-    <SubscriptionProvider>
       <AuthProvider>
+      <SubscriptionProvider>
       <Theme>
         <div className="flex flex-col min-h-screen">
           <Header />
@@ -19,8 +19,8 @@ const MainLayout = ({ children }) => {
           <Footer />
         </div>
       </Theme>
+      </SubscriptionProvider>
     </AuthProvider>
-    </SubscriptionProvider>
   );
 };
 

--- a/src/views/OwnerHomePage/OwnerHomePage.jsx
+++ b/src/views/OwnerHomePage/OwnerHomePage.jsx
@@ -1,7 +1,11 @@
 import { Button, Flex, Heading } from "@radix-ui/themes";
+import { useContext, useEffect } from "react";
 import { Link } from "react-router-dom";
+import SubscriptionContext from "../../utils/context/SubscriptionContext";
+
 
 export default function OwnerHomePage() {
+
   return (
     <>
       <Flex align="center" justify="center" direction="row">


### PR DESCRIPTION
A la hora de obtener el plan del owner, ejecutar la función `getOwnerSubscription` y acto seguido se almacenará en el estado `ownerSubscription`, ambos usando el `SubscriptionContext`.
 
Para usar ambos, incluir al principio del componente la siguiente linea:
`const {getOwnerSubscription, ownerSubscription } = useContext(SubscriptionContext)`

Para obtener el tipo de plan. usar `ownerSubscription.owner_plan`